### PR TITLE
Mention which versions are affected for some of the affected mods

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,28 +45,28 @@ Although some of them already are fixed in the latest versions, these mods were 
 Because of the rushed announcement, we are currently unable to give exact version ranges of affected mods. If you want to help out with that, feel free to contribute to this list.
 
 - AetherCraft
-- Advent of Ascension (Nevermine)
+- Advent of Ascension (Nevermine) (Only affects versions for Minecraft 1.12.2)
 - Arrows Plus
 - Astral Sorcery (affected versions: <=1.9.1)
-- BdLib
+- BdLib (Only affects versions for Minecraft 1.8.9-1.12.2)
 - Carbonization
 - Custom Friends Capes
 - DankNull
 - Energy Manipulation
-- EnderCore
+- EnderCore (Only affects versions for Minecraft 1.9-1.13)
 - EndermanEvolution
 - Extrafirma
 - Gadomancy
 - Giacomo's Bookshelf
-- Immersive Armors
+- Immersive Armors (Fixed in version 1.5.6 for Minecraft 1.18.2, 1.19.2-1.19.4, 1.20, versions for 1.16.5, 1.17.1, 1.18.1, 1.19.0, 1.19.1 remain affected, [relevant commit](https://github.com/Luke100000/ImmersiveArmors/issues/68))
 - Immersive Aircraft
 - Immersive Paintings
 - JourneyMap (Fixed introduced in 1.16.5-5.7.1 and fixed in 1.16.5-5.7.2 No other versions were effected) 
 - LanteaCraft / SGCraft
-- LogisticsPipes
-- Minecraft Comes Alive (MCA)
-- MattDahEpic Core (MDECore)
-- mxTune
+- LogisticsPipes (Fixed in version 0.10.3.114, [relevant commit](https://github.com/RS485/LogisticsPipes/commit/39a90b8f2d1a2bcc512ec68c3e139f1dac07aa56))
+- Minecraft Comes Alive (MCA) (Only affects versions for Minecraft 1.5.2-1.6.4)
+- MattDahEpic Core (MDECore) (Only affects versions for Minecraft 1.8.8-1.12.2)
+- mxTune (Only affects versions for Minecraft 1.12-1.16.5)
 - p455w0rd's Things
 - Project Blue
 - RadixCore
@@ -75,9 +75,9 @@ Because of the rushed announcement, we are currently unable to give exact versio
 - SmartMoving
 - Strange
 - SuperMartijn642's Config Lib (Fixed in version 1.0.9, [relevant security advisory](https://github.com/SuperMartijn642/SuperMartijn642sConfigLib/security/advisories/GHSA-f4r5-w453-2jx6))
-- Thaumic Tinkerer
+- Thaumic Tinkerer (Fixed in version 2.3-138 for Minecraft 1.7.2, versions for 1.6-1.6.4 remain affected, [relevant commit](https://github.com/Thaumic-Tinkerer/ThaumicTinkerer/commit))
 - Tough Expansion
-- ttCore
+- ttCore (Only affects versions for Minecraft 1.7.10)
 
 ## Credits
 


### PR DESCRIPTION
## Changes:
This PR adds info about which Minecraft versions and mod versions are affected for some of the mods listed under 'affected mods'. I have looked through most of the repositories I could find. A lot of the mods aren't open source or their source code is lost to time.

## Info per mod:
- AetherCraft: still affected
- Advent of Ascension (Nevermine): Only 1.12.2
- Arrows Plus (https://www.minecraftforum.net/forums/mapping-and-modding-java-edition/minecraft-mods/1290719-1-6-2-ssp-smp-arrows-plus-v1-0-0-minecraft): Source code not available
- BdLib: Only 1.8.9-1.12.2
- Carbonization: No source code available
- Custom Friends Capes: No source code available
- DankNull: still affected
- Energy Manipulation (https://www.minecraftforum.net/forums/mapping-and-modding-java-edition/minecraft-mods/1290125-1-6-4-1-6-2-1-5-2-1-4-7-energy-manipulation-1-1): Source code not available
- EnderCore: Only 1.9-1.13
- EndermanEvolution: still affected
- Extrafirma: Seems to be no longer available, https://terrafirmacraft.com/f/topic/4581-tfc-0789-extrafirma-addon-v104/?page=5
- Gadomancy: still affected
- Giacomo's Bookshelf: No source code available
- Immersive Armors: Fixed in version 1.5.6, https://github.com/Luke100000/ImmersiveArmors/issues/68, 1.16.5, 1.17.1, 1.18.1, 1.19.0, 1.19.1 remain affected
- Immersive Aircraft: still affected
- Immersive Paintings: still affected
- LanteaCraft / SGCraft: still affected
- LogisticsPipes: Fixed in 0.10.3.114, https://github.com/RS485/LogisticsPipes/commit/39a90b8f2d1a2bcc512ec68c3e139f1dac07aa56
- Minecraft Comes Alive: Only 1.5.2-1.6.4
- MattDahEpic Core: Only 1.8.8-1.12.2
- mxTune: Only 1.12-1.16.5
- p455w0rd's Things: No source code available
- Project Blue (https://www.csse.canterbury.ac.nz/greg.ewing/minecraft/mods/ProjectBlue/): still affected
- RadixCore: No source code available
- Simple Achievements: still affected
- SmartMoving (https://www.minecraftforum.net/forums/mapping-and-modding-java-edition/minecraft-mods/1274224-smart-moving): No source code available
- Strange: Could not find any reference of the class `svenhjol.strange.scrolls.message.ClientQuestList` in the git history
- Thaumic Tinkerer: Only 1.6-1.7.2, fixed in 2.3-138 for 1.7.2, 1.6-1.6.4 remain affected, https://github.com/Thaumic-Tinkerer/ThaumicTinkerer/commit/4491cae180f97fd2b6e9365cac8212578df2299b
- Tough Expansion: still affected
- ttCore: Only 1.7.10