### PR TITLE
Add patch for CreativeCore (1.7.10)

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ Because of the rushed announcement, we are currently unable to give exact versio
 - [Astral Sorcery](https://www.curseforge.com/minecraft/mc-mods/astral-sorcery) (affected versions: <=1.9.1)
 - [BdLib](https://www.curseforge.com/minecraft/mc-mods/bdlib) (Only affects versions for Minecraft 1.8.9-1.12.2)
 - [Carbonization](https://www.curseforge.com/minecraft/mc-mods/carbonization)
+- [CreativeCore](https://www.curseforge.com/minecraft/mc-mods/creativecore) (Only affects versions for Minecraft 1.7.10)
 - [Custom Friends Capes](https://www.curseforge.com/minecraft/mc-mods/custom-friends-capes)
 - [CustomOreGen](https://www.curseforge.com/minecraft/mc-mods/customoregen)
 - [DankNull](https://www.curseforge.com/minecraft/mc-mods/dank-null)

--- a/serializationisbad.json
+++ b/serializationisbad.json
@@ -340,6 +340,15 @@
             "packageAllowlist": [
                 "tterrag"
             ]
+        },
+        {
+            "classesToPatch": [
+                "com.n247s.N2ConfigApi.api.networking.N2ConfigApiMessageHandler"
+            ],
+            "classAllowlist": [],
+            "packageAllowlist": [
+                "com.n247s"
+            ]
         }
     ],
     "classAllowlist": [


### PR DESCRIPTION
See https://github.com/GTNewHorizons/CreativeCore/pull/4
This class was removed as of 1.8.9 ([commit](https://github.com/CreativeMD/CreativeCore/commit/d3fb8e97b0a06c6f7fb25850d8aa8d4ea2938c86)), so 1.7.10 is the only version affected.